### PR TITLE
Added Set Color and Set Plate Number utility modules

### DIFF
--- a/Enhanced_Zeus_Modules.sqf
+++ b/Enhanced_Zeus_Modules.sqf
@@ -11527,38 +11527,16 @@ MAZ_EZM_fnc_initFunction = {
 			["Object replaced with simple object.","addItemOk"] call MAZ_EZM_fnc_systemMessage;
 		};
 
-		HYPER_EZM_fnc_setColor = {
+		HYPER_EZM_fnc_setColorBlack = {
 			params ["_entity"];
 			if(_entity isEqualTo objNull) exitWith {["No object selected.","addItemFailed"] call MAZ_EZM_fnc_systemMessage;};
-			[
-				"Set Object Color",
-				[
-					[
-						"COLOR",
-						"Pick a Color",
-						[ 
-							[0, 0, 0, 1],
-							false
-						]
-					]
-				], 
-				{
-					params ["_values", "_args", "_display"];
-					private _color = _values select 0;
-					private _entity = _args;
-					private _newColor = format ["#(argb,8,8,3)color(%1,%2,%3,%4)", (_color select 0), (_color select 1), (_color select 2), (_color select 3)];
-					{
-						_entity setObjectTextureGlobal [_forEachIndex, _newColor];
-					} forEach (getObjectTextures _entity);
 
-					["Changed object color.","addItemOk"] call MAZ_EZM_fnc_systemMessage;
-					_display closeDisplay 1; 
-				}, 
-				{ 
-					_display closeDisplay 2; 
-				}, 
-				_entity 
-			] call MAZ_EZM_fnc_createDialog;
+			private _colorBlack = "#(argb,8,8,3)color(0,0,0,1)";
+			{
+				_entity setObjectTextureGlobal [_forEachIndex, _colorBlack];
+			} forEach (getObjectTextures _entity);
+
+			["Changed object color.","addItemOk"] call MAZ_EZM_fnc_systemMessage;
 
 		};
 
@@ -16990,9 +16968,9 @@ MAZ_EZM_fnc_editZeusInterface = {
 				[
 					MAZ_zeusModulesTree,
 					MAZ_ObjectModTree,
-					"Set Color",
-					"Changes textures of an object / unit to a color if possible.",
-					"HYPER_EZM_fnc_setColor",
+					"Set Color to Black",
+					"Changes textures of an object / unit to black if possible.",
+					"HYPER_EZM_fnc_setColorBlack",
 					"a3\ui_f\data\gui\rsc\rscdisplaygarage\texturesources_ca.paa"
 				] call MAZ_EZM_fnc_zeusAddModule;
 

--- a/Enhanced_Zeus_Modules.sqf
+++ b/Enhanced_Zeus_Modules.sqf
@@ -14111,6 +14111,42 @@ MAZ_EZM_fnc_initFunction = {
 			["Vehicle repaired.","addItemOk"] call MAZ_EZM_fnc_systemMessage;
 		};
 
+		HYPER_EZM_fnc_setPlateNumber = {
+			params ["_entity"];
+			if (!(_entity isKindOf "Car_F")) exitWith {
+				["This is not a vehicle!","addItemFailed"] call MAZ_EZM_fnc_systemMessage;
+			};
+			[
+				"Set License Plate Number",
+				[ 
+					[
+						"EDIT",
+						"Plate Number (12 chars max)",
+						[ 
+							"", 
+							1 
+						]
+					]
+				], 
+				{
+					params ["_values", "_args", "_display"];
+					private _entity = _args;
+					private _inputText = _values select 0;
+					if (count _inputText > 12) then {
+						_inputText = _inputText select [0, 12];
+					};
+					_entity setPlateNumber _inputText;
+					["License Plate Number set.","addItemOk"] call MAZ_EZM_fnc_systemMessage;
+					_display closeDisplay 1; 
+				}, 
+				{ 
+					_display closeDisplay 2; 
+				}, 
+				_entity
+			] call MAZ_EZM_fnc_createDialog;
+
+		};
+
 	comment "Zeus";
 
 		MAZ_EZM_fnc_toggleGameModerator = {
@@ -17377,6 +17413,15 @@ MAZ_EZM_fnc_editZeusInterface = {
 					"Repair the vehicle.",
 					"MAZ_EZM_fnc_repairVehicleModule",
 					'\A3\ui_f\data\IGUI\Cfg\simpleTasks\types\repair_ca.paa'
+				] call MAZ_EZM_fnc_zeusAddModule;
+				
+				[
+					MAZ_zeusModulesTree,
+					MAZ_VehicleModTree,
+					"Set Plate Number",
+					"Set the license plate number of a car.",
+					"HYPER_EZM_fnc_setPlateNumber",
+					"a3\ui_f\data\igui\cfg\simpletasks\types\car_ca.paa"
 				] call MAZ_EZM_fnc_zeusAddModule;
 
 			comment "Zeus";

--- a/Enhanced_Zeus_Modules.sqf
+++ b/Enhanced_Zeus_Modules.sqf
@@ -11527,6 +11527,41 @@ MAZ_EZM_fnc_initFunction = {
 			["Object replaced with simple object.","addItemOk"] call MAZ_EZM_fnc_systemMessage;
 		};
 
+		HYPER_EZM_fnc_setColor = {
+			params ["_entity"];
+			if(_entity isEqualTo objNull) exitWith {["No object selected.","addItemFailed"] call MAZ_EZM_fnc_systemMessage;};
+			[
+				"Set Object Color",
+				[
+					[
+						"COLOR",
+						"Pick a Color",
+						[ 
+							[0, 0, 0, 1],
+							false
+						]
+					]
+				], 
+				{
+					params ["_values", "_args", "_display"];
+					private _color = _values select 0;
+					private _entity = _args;
+					private _newColor = format ["#(argb,8,8,3)color(%1,%2,%3,%4)", (_color select 0), (_color select 1), (_color select 2), (_color select 3)];
+					{
+						_entity setObjectTextureGlobal [_forEachIndex, _newColor];
+					} forEach (getObjectTextures _entity);
+
+					["Object replaced with simple object.","addItemOk"] call MAZ_EZM_fnc_systemMessage;
+					_display closeDisplay 1; 
+				}, 
+				{ 
+					_display closeDisplay 2; 
+				}, 
+				_entity 
+			] call MAZ_EZM_fnc_createDialog;
+
+		};
+
 	comment "Player Modifiers";
 
 		MAZ_EZM_fnc_disarmModule = {
@@ -16914,6 +16949,15 @@ MAZ_EZM_fnc_editZeusInterface = {
 					"Replaces the object it's placed on with a simple object to improve performance.",
 					"MAZ_EZM_fnc_replaceWithSimpleObject",
 					"a3\3den\data\cfgwaypoints\scripted_ca.paa"
+				] call MAZ_EZM_fnc_zeusAddModule;
+				
+				[
+					MAZ_zeusModulesTree,
+					MAZ_ObjectModTree,
+					"Set Color",
+					"Changes textures of an object / unit to a color if possible.",
+					"HYPER_EZM_fnc_setColor",
+					"a3\ui_f\data\gui\rsc\rscdisplaygarage\texturesources_ca.paa"
 				] call MAZ_EZM_fnc_zeusAddModule;
 
 				[

--- a/Enhanced_Zeus_Modules.sqf
+++ b/Enhanced_Zeus_Modules.sqf
@@ -11551,7 +11551,7 @@ MAZ_EZM_fnc_initFunction = {
 						_entity setObjectTextureGlobal [_forEachIndex, _newColor];
 					} forEach (getObjectTextures _entity);
 
-					["Object replaced with simple object.","addItemOk"] call MAZ_EZM_fnc_systemMessage;
+					["Changed object color.","addItemOk"] call MAZ_EZM_fnc_systemMessage;
 					_display closeDisplay 1; 
 				}, 
 				{ 

--- a/Enhanced_Zeus_Modules.sqf
+++ b/Enhanced_Zeus_Modules.sqf
@@ -14099,9 +14099,9 @@ MAZ_EZM_fnc_initFunction = {
 				[ 
 					[
 						"EDIT",
-						"Plate Number (12 chars max)",
+						["Plate Number", "The maximum length of a plate number is 12 characters"],
 						[ 
-							"", 
+							getPlateNumber _entity, 
 							1 
 						]
 					]
@@ -14113,7 +14113,7 @@ MAZ_EZM_fnc_initFunction = {
 					if (count _inputText > 12) then {
 						_inputText = _inputText select [0, 12];
 					};
-					_entity setPlateNumber _inputText;
+					[_entity,_inputText] remoteExec ["setPlateNumber"];
 					["License Plate Number set.","addItemOk"] call MAZ_EZM_fnc_systemMessage;
 					_display closeDisplay 1; 
 				}, 


### PR DESCRIPTION
### Set Color
**Object Modifier:** A primitive version of the classic `Set Color` command utilizing the new color picker input (thanks @expung3d) which applies an RGBA color to any available texture channel on the selected object.
![20241215221311_1](https://github.com/user-attachments/assets/dbd96a22-08df-41f0-9b9a-6ff8c7271402)
![20241215221301_1](https://github.com/user-attachments/assets/036d47ab-e529-4042-8c20-96d22a1b05bc)

### Set Plate Number
**Vehicle Modifier:** Allows Zeus to update the global license plate number on a vehicle of type `Car_F`. Useful tool for Zeus players looking to customize vehicles for themed missions. Maximum of 12 characters will fit on the plate.
![20241215232502_1](https://github.com/user-attachments/assets/2982b739-5359-4e58-9060-c5549c4fcf0a)
![20241215232509_1](https://github.com/user-attachments/assets/3ffe3e21-9a64-4d28-a18b-3d5df1e794c6)

