### PR TITLE
AAN News Article Intel Module

### DIFF
--- a/Enhanced_Zeus_Modules.sqf
+++ b/Enhanced_Zeus_Modules.sqf
@@ -10634,7 +10634,7 @@ MAZ_EZM_fnc_initFunction = {
 
 	
 		HYPER_EZM_fnc_handleCreateIntelDetails = {
-			params ["_values"];
+			params ["_values", "_target"];
 			_values params ["_title","_authorName","_timestamp","_timezone","_subtitle","_image","_bodyText","_bodyTextLocked"];
 
 			systemChat format ["Creating Intel: %1",_title];
@@ -10680,11 +10680,41 @@ MAZ_EZM_fnc_initFunction = {
 			if (_bodyText != "") then {_intelOptions pushBack ["text",_bodyText];};
 			if (_bodyTextLocked != "") then {_intelOptions pushBack ["textlocked",[_bodyTextLocked,"Please Subscribe"]];};
 
-			[ _intelOptions ] call BIS_fnc_showAANArticle;
+			private _intelObj = "Item_Laptop_Unfolded" createVehicle _target;
+			_intelObj setDamage 1;
+			_intelObj setPosATL _target;
 
+			private _actionParams = [
+				_intelObj,
+				"<t color='#ff9b00'>View News Article</t>", 
+				"a3\ui_f\data\igui\cfg\holdactions\holdaction_search_ca.paa", 
+				"a3\ui_f\data\igui\cfg\holdactions\holdaction_search_ca.paa", 
+				"_this distance _target < 3",
+				"_caller distance _target < 3",  
+				{},
+				{},
+				{
+					private _args = _this select 3;
+					_args params ["_intelOptions"];
+
+					[ _intelOptions ] call BIS_fnc_showAANArticle;
+
+				},
+				{},
+				[_intelOptions],
+				2, 
+				10, 
+				false,
+				false 
+			];
+			_actionParams remoteExec ["BIS_fnc_holdActionAdd", 0, _intelObj];
+
+			[_intelObj] call MAZ_EZM_fnc_addObjectToInterface;
+			["AAN article laptop created.","addItemOk"] call MAZ_EZM_fnc_systemMessage;
 		};
 
 		HYPER_EZM_fnc_createAANIntel = {
+			private _target = [true] call MAZ_EZM_fnc_getScreenPosition;
 			private _dialogTitle = "Create Intel";
 			private _content = [
 				[
@@ -10756,13 +10786,13 @@ MAZ_EZM_fnc_initFunction = {
 			private _onConfirm = {
 				params ["_values", "_args", "_display"];
 				_values params ["_title","_authorName","_timestamp","_timezone","_subtitle","_image","_bodyText","_bodyTextLocked"];
+				private _target = _args;
 
-				[ _values ] call HYPER_EZM_fnc_handleCreateIntelDetails;
+				[ _values, _target ] call HYPER_EZM_fnc_handleCreateIntelDetails;
 				_display closeDisplay 1;
 			};
 			private _onCancel = {
 				params ["_values", "_args", "_display"];
-				systemChat "Create Intel dialog canceled.";
 				_display closeDisplay 2;
 			};
 			[
@@ -10770,7 +10800,7 @@ MAZ_EZM_fnc_initFunction = {
 				_content,
 				_onConfirm,
 				_onCancel,
-				[]
+				_target
 			] call MAZ_EZM_fnc_createDialog;
 		};
 

--- a/Enhanced_Zeus_Modules.sqf
+++ b/Enhanced_Zeus_Modules.sqf
@@ -9480,6 +9480,103 @@ MAZ_EZM_fnc_initFunction = {
 			
 		};
 
+		HYPER_EZM_fnc_handleCreateIntelDetails = {
+			params ["_values"];
+			_values params ["_title","_authorName","_timestamp","_timezone","_subtitle","_image","_bodyText","_bodyTextLocked"];
+
+
+		};
+
+		HYPER_EZM_fnc_introCinematicAAN = {
+			private _dialogTitle = "Create Intel";
+			private _content = [
+				[
+					"EDIT",
+					["Title", "The headline title of the article."],
+					[
+						"My Title",
+						1
+					]
+				],
+				[
+					"EDIT",
+					["Author Name", "The name of the author."],
+					[
+						name player,
+						1
+					]
+				],
+				[
+					"EDIT",
+					["Timestamp", "The date and time of the article, which MUST follow the format YYYY/MM/DD HH:MM."],
+					[
+						"2035/01/31 10:00",
+						1
+					]
+				],
+				[
+					"EDIT",
+					["Timezone", "The timezone of the article."],
+					[
+						"CET",
+						1
+					]
+				],
+				[
+					"EDIT",
+					["Subtitle", "A brief description of the article under the main title."],
+					[
+						"",
+						1
+					]
+				],
+				[
+					"COMBO",
+					["Image", "The image to be displayed with the article headline."],
+					[
+						["image1", "image2", "image3"],
+						["Image 1", "Image 2", "Image 3"],
+						0
+					]
+				],
+				[
+					"EDIT:MULTI",
+					["Body Text", "The main body of the article."],
+					[
+						"",
+						5
+					]
+				],
+				[
+					"EDIT:MULTI",
+					["Body Text Locked", "A paragraph that is cut off by a subscription paywall."],
+					[
+						"",
+						3
+					]
+				]
+			];
+			private _onConfirm = {
+				params ["_values", "_args", "_display"];
+				_values params ["_title","_authorName","_timestamp","_timezone","_subtitle","_image","_bodyText","_bodyTextLocked"];
+
+				[ _values ] call HYPER_EZM_fnc_handleCreateIntelDetails;
+				_display closeDisplay 1;
+			};
+			private _onCancel = {
+				params ["_values", "_args", "_display"];
+				systemChat "Create Intel dialog canceled.";
+				_display closeDisplay 2;
+			};
+			[
+				_dialogTitle,
+				_content,
+				_onConfirm,
+				_onCancel,
+				[]
+			] call MAZ_EZM_fnc_createDialog;
+		};
+
 		if(isNil "MAZ_EZM_fnc_createCinematicCam") then {
 			MAZ_EZM_fnc_createCinematicCam = {
 				call MAZ_EZM_fnc_destroyCinematicCamera;
@@ -16848,6 +16945,15 @@ MAZ_EZM_fnc_editZeusInterface = {
 					"Create Intel",
 					"Creates an intel object to be picked up by the players.\nCreated by: Bijx",
 					"HYPER_EZM_fnc_createIntel",
+					"a3\ui_f\data\igui\cfg\simpletasks\types\documents_ca.paa"
+				] call MAZ_EZM_fnc_zeusAddModule;
+
+				[
+					MAZ_zeusModulesTree,
+					MAZ_GameplayTree,
+					"Create AAN News Article",
+					"Creates a laptop which shows an AAN News Article when interacted on.\nCreated by: Bijx",
+					"HYPER_EZM_fnc_introCinematicAAN",
 					"a3\ui_f\data\igui\cfg\simpletasks\types\documents_ca.paa"
 				] call MAZ_EZM_fnc_zeusAddModule;
 

--- a/Enhanced_Zeus_Modules.sqf
+++ b/Enhanced_Zeus_Modules.sqf
@@ -10637,8 +10637,6 @@ MAZ_EZM_fnc_initFunction = {
 			params ["_values", "_target"];
 			_values params ["_title","_authorName","_timestamp","_timezone","_subtitle","_image","_bodyText","_bodyTextLocked"];
 
-			systemChat format ["Creating Intel: %1",_title];
-
 			HYPER_safeParse = {
 				params ["_str"];
 				private _num = parseNumber _str;
@@ -10672,18 +10670,24 @@ MAZ_EZM_fnc_initFunction = {
 				[_year, _month, _day, _hour, _minute]
 			};
 			private _intelOptions = [];
-
+			
+			comment "Metadata group validation";
 			private _timestampParts = _timestamp call HYPER_fnc_parseTimestamp;
+			if (_authorName == "") then {_authorName = "Anonymous";};
+			if (_timezone == "") then {_timezone = "UTC";};
+			_intelOptions pushBack ["meta",[_authorName,_timestampParts,_timezone]];
+
+			comment "Other field validation";
 			if (_title != "") then {_intelOptions pushBack ["title",_title];};
-			if (_authorName != "") then {_intelOptions pushBack ["meta",[_authorName,_timestampParts,_timezone]];};
 			if (_subtitle != "") then {_intelOptions pushBack ["textbold",_subtitle];};
 			if (_bodyText != "") then {_intelOptions pushBack ["text",_bodyText];};
 			if (_bodyTextLocked != "") then {_intelOptions pushBack ["textlocked",[_bodyTextLocked,"Please Subscribe"]];};
 
-			private _intelObj = "Item_Laptop_Unfolded" createVehicle _target;
+			comment "Create intel object and action";
+			private _intelObj = "Land_Laptop_unfolded_F" createVehicle _target;
 			_intelObj setDamage 1;
 			_intelObj setPosATL _target;
-			_intelObj setObjectTextureGlobal "a3\missions_f_orange\data\img\orange_compositions\c8\aan_co.paa";
+			_intelObj setObjectTextureGlobal [0, "a3\missions_f_orange\data\img\orange_compositions\c8\aan_co.paa"];
 
 			private _actionParams = [
 				_intelObj,
@@ -10809,7 +10813,7 @@ MAZ_EZM_fnc_initFunction = {
 			params ["_title","_description","_intelObject","_deleteOnPickup", "_target", "_holdDuration", "_visibility"];
 
 			private _intelObjModel = switch (_intelObject) do {
-				case "laptop": {"Item_Laptop_Unfolded"};
+				case "laptop": {"Land_Laptop_unfolded_F"};
 				case "ruggedtablet": {"Land_Tablet_02_black_F"};
 				case "tablet": {"Land_Tablet_01_F"};
 				case "documents": {"LanD_File1_f"};

--- a/Enhanced_Zeus_Modules.sqf
+++ b/Enhanced_Zeus_Modules.sqf
@@ -10670,6 +10670,33 @@ MAZ_EZM_fnc_initFunction = {
 				[_year, _month, _day, _hour, _minute]
 			};
 			private _intelOptions = [];
+
+			comment "Image banner validation";
+			private _imageTexture = switch (_image) do {
+				case "warthog": {"a3\missions_f_aow\data\img\artwork\landscape\showcase_aow_picture_64_co.paa"};
+				case "divers": {"a3\missions_f_aow\data\img\artwork\landscape\showcase_aow_picture_65_co.paa"};
+				case "breach": {"a3\missions_f_aow\data\img\artwork\landscape\showcase_aow_picture_04_co.paa"};
+				case "ww2medical": {"a3\missions_f_aow\data\img\artwork\landscape\showcase_aow_picture_14_co.paa"};
+				case "exfil": {"a3\missions_f_aow\data\img\artwork\landscape\showcase_aow_picture_106_co.paa"};
+				case "soldiers": {"a3\missions_f_aow\data\img\artwork\landscape\showcase_aow_picture_59_co.paa"};
+				case "schematic": {"a3\missions_f_aow\data\img\artwork\landscape\showcase_aow_picture_63_co.paa"};
+				case "riot": {"a3\missions_f_aow\data\img\artwork\landscape\showcase_aow_picture_22_co.paa"};
+				case "ambulance": {"a3\missions_f_aow\data\img\artwork\landscape\showcase_aow_picture_62_co.paa"};
+				case "ww2attack": {"a3\missions_f_aow\data\img\artwork\landscape\showcase_aow_picture_92_co.paa"};
+				case "ghosts": {"a3\missions_f_aow\data\img\artwork\landscape\showcase_aow_picture_18_co.paa"};
+				case "town": {"a3\missions_f_aow\data\img\artwork\landscape\showcase_aow_picture_68_co.paa"};
+				case "decon": {"a3\missions_f_aow\data\img\artwork\landscape\showcase_aow_picture_31_co.paa"};
+				case "tank": {"a3\missions_f_aow\data\img\artwork\landscape\showcase_aow_picture_98_co.paa"};
+				case "launcher": {"a3\missions_f_aow\data\img\artwork\landscape\showcase_aow_picture_122_co.paa"};
+				case "cargotrain": {"a3\missions_f_aow\data\img\artwork\landscape\showcase_aow_picture_27_co.paa"};
+				case "convoy": {"a3\missions_f_aow\data\img\artwork\landscape\showcase_aow_picture_87_co.paa"};
+				case "fallen": {"a3\missions_f_aow\data\img\artwork\landscape\showcase_aow_picture_118_co.paa"};
+				case "firefight": {"a3\missions_f_aow\data\img\artwork\landscape\showcase_aow_picture_76_co.paa"};
+				case "fleet": {"a3\missions_f_aow\data\img\artwork\landscape\showcase_aow_picture_46_co.paa"};
+				case "drones": {"a3\missions_f_aow\data\img\artwork\landscape\showcase_aow_picture_30_co.paa"};
+				default {"a3\missions_f_aow\data\img\artwork\landscape\showcase_aow_picture_64_co.paa"};
+			};
+			_intelOptions pushBack ["image",_imageTexture];
 			
 			comment "Metadata group validation";
 			private _timestampParts = _timestamp call HYPER_fnc_parseTimestamp;
@@ -10766,8 +10793,8 @@ MAZ_EZM_fnc_initFunction = {
 					"COMBO",
 					["Image", "The image to be displayed with the article headline."],
 					[
-						["image1", "image2", "image3"],
-						["Image 1", "Image 2", "Image 3"],
+						["warthog", "divers", "breach", "ww2medical", "exfil", "soldiers", "schematic", "riot", "ambulance", "ww2attack", "ghosts", "town", "decon", "tank", "launcher", "cargotrain", "convoy", "fallen", "firefight", "fleet", "drones"],
+						["A-10 Warthog", "Divers", "Breach and Clear", "WW2 Medical", "Helo Exfil", "Two Soldiers", "Plane Schematic", "Riot", "Ambulance", "WW2 Assault", "Ghosts of War", "Town Liberated", "Decon Showers", "Tank", "Launcher", "Cargo Train", "Convoy", "Coffin Salute", "Firefight", "Carrier Fleet", "Small Drones"],
 						0
 					]
 				],

--- a/Enhanced_Zeus_Modules.sqf
+++ b/Enhanced_Zeus_Modules.sqf
@@ -9480,103 +9480,6 @@ MAZ_EZM_fnc_initFunction = {
 			
 		};
 
-		HYPER_EZM_fnc_handleCreateIntelDetails = {
-			params ["_values"];
-			_values params ["_title","_authorName","_timestamp","_timezone","_subtitle","_image","_bodyText","_bodyTextLocked"];
-
-
-		};
-
-		HYPER_EZM_fnc_introCinematicAAN = {
-			private _dialogTitle = "Create Intel";
-			private _content = [
-				[
-					"EDIT",
-					["Title", "The headline title of the article."],
-					[
-						"My Title",
-						1
-					]
-				],
-				[
-					"EDIT",
-					["Author Name", "The name of the author."],
-					[
-						name player,
-						1
-					]
-				],
-				[
-					"EDIT",
-					["Timestamp", "The date and time of the article, which MUST follow the format YYYY/MM/DD HH:MM."],
-					[
-						"2035/01/31 10:00",
-						1
-					]
-				],
-				[
-					"EDIT",
-					["Timezone", "The timezone of the article."],
-					[
-						"CET",
-						1
-					]
-				],
-				[
-					"EDIT",
-					["Subtitle", "A brief description of the article under the main title."],
-					[
-						"",
-						1
-					]
-				],
-				[
-					"COMBO",
-					["Image", "The image to be displayed with the article headline."],
-					[
-						["image1", "image2", "image3"],
-						["Image 1", "Image 2", "Image 3"],
-						0
-					]
-				],
-				[
-					"EDIT:MULTI",
-					["Body Text", "The main body of the article."],
-					[
-						"",
-						5
-					]
-				],
-				[
-					"EDIT:MULTI",
-					["Body Text Locked", "A paragraph that is cut off by a subscription paywall."],
-					[
-						"",
-						3
-					]
-				]
-			];
-			private _onConfirm = {
-				params ["_values", "_args", "_display"];
-				_values params ["_title","_authorName","_timestamp","_timezone","_subtitle","_image","_bodyText","_bodyTextLocked"];
-
-				[ _values ] call HYPER_EZM_fnc_handleCreateIntelDetails;
-				_display closeDisplay 1;
-			};
-			private _onCancel = {
-				params ["_values", "_args", "_display"];
-				systemChat "Create Intel dialog canceled.";
-				_display closeDisplay 2;
-			};
-			[
-				_dialogTitle,
-				_content,
-				_onConfirm,
-				_onCancel,
-				[]
-			] call MAZ_EZM_fnc_createDialog;
-		};
-
 		if(isNil "MAZ_EZM_fnc_createCinematicCam") then {
 			MAZ_EZM_fnc_createCinematicCam = {
 				call MAZ_EZM_fnc_destroyCinematicCamera;
@@ -10728,6 +10631,148 @@ MAZ_EZM_fnc_initFunction = {
 		};
 
 	comment "Gameplay";
+
+	
+		HYPER_EZM_fnc_handleCreateIntelDetails = {
+			params ["_values"];
+			_values params ["_title","_authorName","_timestamp","_timezone","_subtitle","_image","_bodyText","_bodyTextLocked"];
+
+			systemChat format ["Creating Intel: %1",_title];
+
+			HYPER_safeParse = {
+				params ["_str"];
+				private _num = parseNumber _str;
+				if ((_num == 0) && (_str != "0")) then {
+					-1
+				} else {
+					_num
+				}
+			};
+
+			HYPER_fnc_parseTimestamp = {
+				params ["_dateString"];
+				private _defaultDate = [2035, 1, 1, 10, 38];
+				private _parts = _dateString splitString " ";
+				if (count _parts != 2) exitWith {_defaultDate};
+				private _datePart = _parts select 0;
+				private _timePart = _parts select 1;
+				private _dateComponents = _datePart splitString "/";
+				if (count _dateComponents != 3) exitWith {_defaultDate};
+				private _timeComponents = _timePart splitString ":";
+				if (count _timeComponents != 2) exitWith {_defaultDate};
+
+				private _year   = [_dateComponents select 0] call HYPER_safeParse;
+				private _month  = [_dateComponents select 1] call HYPER_safeParse;
+				private _day    = [_dateComponents select 2] call HYPER_safeParse;
+				private _hour   = [_timeComponents select 0] call HYPER_safeParse;
+				private _minute = [_timeComponents select 1] call HYPER_safeParse;
+				if ( (_year == -1) || (_month == -1) || (_day == -1) || (_hour == -1) || (_minute == -1) ) exitWith {_defaultDate};
+				if (!((_year >= 0) && (_month >= 1 && _month <= 12) && (_day >= 1 && _day <= 31) && 
+					(_hour >= 0 && _hour <= 23) && (_minute >= 0 && _minute <= 59))) exitWith {_defaultDate};
+				[_year, _month, _day, _hour, _minute]
+			};
+			private _intelOptions = [];
+
+			private _timestampParts = _timestamp call HYPER_fnc_parseTimestamp;
+			if (_title != "") then {_intelOptions pushBack ["title",_title];};
+			if (_authorName != "") then {_intelOptions pushBack ["meta",[_authorName,_timestampParts,_timezone]];};
+			if (_subtitle != "") then {_intelOptions pushBack ["textbold",_subtitle];};
+			if (_bodyText != "") then {_intelOptions pushBack ["text",_bodyText];};
+			if (_bodyTextLocked != "") then {_intelOptions pushBack ["textlocked",[_bodyTextLocked,"Please Subscribe"]];};
+
+			[ _intelOptions ] call BIS_fnc_showAANArticle;
+
+		};
+
+		HYPER_EZM_fnc_createAANIntel = {
+			private _dialogTitle = "Create Intel";
+			private _content = [
+				[
+					"EDIT",
+					["Title", "The headline title of the article."],
+					[
+						"My Title",
+						1
+					]
+				],
+				[
+					"EDIT",
+					["Author Name", "The name of the author."],
+					[
+						name player,
+						1
+					]
+				],
+				[
+					"EDIT",
+					["Timestamp", "The date and time of the article, which MUST follow the format YYYY/MM/DD HH:MM."],
+					[
+						"2035/01/31 10:00",
+						1
+					]
+				],
+				[
+					"EDIT",
+					["Timezone", "The timezone of the article."],
+					[
+						"CET",
+						1
+					]
+				],
+				[
+					"EDIT",
+					["Subtitle", "A brief description of the article under the main title."],
+					[
+						"",
+						1
+					]
+				],
+				[
+					"COMBO",
+					["Image", "The image to be displayed with the article headline."],
+					[
+						["image1", "image2", "image3"],
+						["Image 1", "Image 2", "Image 3"],
+						0
+					]
+				],
+				[
+					"EDIT:MULTI",
+					["Body Text", "The main body of the article."],
+					[
+						"",
+						5
+					]
+				],
+				[
+					"EDIT:MULTI",
+					["Body Text Locked", "A paragraph that is cut off by a subscription paywall."],
+					[
+						"",
+						3
+					]
+				]
+			];
+			private _onConfirm = {
+				params ["_values", "_args", "_display"];
+				_values params ["_title","_authorName","_timestamp","_timezone","_subtitle","_image","_bodyText","_bodyTextLocked"];
+
+				[ _values ] call HYPER_EZM_fnc_handleCreateIntelDetails;
+				_display closeDisplay 1;
+			};
+			private _onCancel = {
+				params ["_values", "_args", "_display"];
+				systemChat "Create Intel dialog canceled.";
+				_display closeDisplay 2;
+			};
+			[
+				_dialogTitle,
+				_content,
+				_onConfirm,
+				_onCancel,
+				[]
+			] call MAZ_EZM_fnc_createDialog;
+		};
 
 		HYPER_EZM_fnc_handleCreateIntel = {
 			params ["_title","_description","_intelObject","_deleteOnPickup", "_target", "_holdDuration", "_visibility"];
@@ -16953,7 +16998,7 @@ MAZ_EZM_fnc_editZeusInterface = {
 					MAZ_GameplayTree,
 					"Create AAN News Article",
 					"Creates a laptop which shows an AAN News Article when interacted on.\nCreated by: Bijx",
-					"HYPER_EZM_fnc_introCinematicAAN",
+					"HYPER_EZM_fnc_createAANIntel",
 					"a3\ui_f\data\igui\cfg\simpletasks\types\documents_ca.paa"
 				] call MAZ_EZM_fnc_zeusAddModule;
 

--- a/Enhanced_Zeus_Modules.sqf
+++ b/Enhanced_Zeus_Modules.sqf
@@ -10696,17 +10696,17 @@ MAZ_EZM_fnc_initFunction = {
 				case "drones": {"a3\missions_f_aow\data\img\artwork\landscape\showcase_aow_picture_30_co.paa"};
 				default {"a3\missions_f_aow\data\img\artwork\landscape\showcase_aow_picture_64_co.paa"};
 			};
-			_intelOptions pushBack ["image",_imageTexture];
 			
 			comment "Metadata group validation";
 			private _timestampParts = _timestamp call HYPER_fnc_parseTimestamp;
 			if (_authorName == "") then {_authorName = "Anonymous";};
 			if (_timezone == "") then {_timezone = "UTC";};
-			_intelOptions pushBack ["meta",[_authorName,_timestampParts,_timezone]];
 
 			comment "Other field validation";
 			if (_title != "") then {_intelOptions pushBack ["title",_title];};
+			_intelOptions pushBack ["meta",[_authorName,_timestampParts,_timezone]];
 			if (_subtitle != "") then {_intelOptions pushBack ["textbold",_subtitle];};
+			_intelOptions pushBack ["image",_imageTexture];
 			if (_bodyText != "") then {_intelOptions pushBack ["text",_bodyText];};
 			if (_bodyTextLocked != "") then {_intelOptions pushBack ["textlocked",[_bodyTextLocked,"Please Subscribe"]];};
 

--- a/Enhanced_Zeus_Modules.sqf
+++ b/Enhanced_Zeus_Modules.sqf
@@ -10683,6 +10683,7 @@ MAZ_EZM_fnc_initFunction = {
 			private _intelObj = "Item_Laptop_Unfolded" createVehicle _target;
 			_intelObj setDamage 1;
 			_intelObj setPosATL _target;
+			_intelObj setObjectTextureGlobal "a3\missions_f_orange\data\img\orange_compositions\c8\aan_co.paa";
 
 			private _actionParams = [
 				_intelObj,


### PR DESCRIPTION
_Disregard branch name, forgot to rename it._

This module adds in the ability for Zeus players to add a new type of intel object to their scenarios, the AAN News Article. It will create a laptop with a news texture and allow players to interact on it to see the intel.

![image](https://github.com/user-attachments/assets/85b8e6b0-7d22-41b5-9d3c-ef36ccad8747)
![image](https://github.com/user-attachments/assets/bed41612-9ff0-4fe1-adc3-619e64d7eca9)
![image](https://github.com/user-attachments/assets/c613f847-7f1a-4948-97ba-f1d532cb0a3d)
![image](https://github.com/user-attachments/assets/b6c82860-72ba-461e-b377-4d2bfa33e9e3)
