### PR TITLE
AAN News Helicopter Intro Cinematic

### DIFF
--- a/Enhanced_Zeus_Modules.sqf
+++ b/Enhanced_Zeus_Modules.sqf
@@ -9404,6 +9404,11 @@ MAZ_EZM_fnc_initFunction = {
 					[[_target],HYPER_fnc_remoteCamera] remoteExec ["spawn", _allPlayers];
 				};
 				case "News": {
+					[[],{
+						playSoundUI ["a3\sounds_f\vehicles\air\heli_attack_01\heli_attack_01_ext_rotor.wss", 0.2];
+						sleep 7.5;
+						playSoundUI ["a3\sounds_f\vehicles\air\heli_attack_01\heli_attack_01_ext_rotor.wss", 0.2];
+					}] remoteExec ["spawn", _allPlayers];
 					private _AANParams = [
 						parseText _briefingName,
 						parseText format["BREAKING NEWS - REPORTING LIVE FROM %1", worldName]
@@ -9424,7 +9429,7 @@ MAZ_EZM_fnc_initFunction = {
 
 					private _angle = 0;
 					private _zoom = 0.75;
-					while {_angle <= 180} do {
+					while {_angle <= 155} do {
 						private _posMove = _pos getPos [200,_angle];
 						_posMove set [2,_height];
 
@@ -9495,7 +9500,7 @@ MAZ_EZM_fnc_initFunction = {
 				[
 					"TOOLBOX:YESNO",
 					["Zeus Can See Cutscene?","Zeus player may experience a small lag spike when cutscene ends."],
-					[false]
+					[true]
 				],
 				[
 					"COMBO",

--- a/Enhanced_Zeus_Modules.sqf
+++ b/Enhanced_Zeus_Modules.sqf
@@ -9371,10 +9371,11 @@ MAZ_EZM_fnc_initFunction = {
 						private _camSrc0 = [_target select 0, (_target select 1) + _circleRadius, (_target select 2) + _camHeight];
 						private _camSrc90 = [(_target select 0) + _circleRadius, _target select 1, (_target select 2) + _camHeight];
 						
-						private _camera = "camera" camCreate _camSrc0;
-						_camera cameraEffect ["internal", "back"];
+						private _camera = call MAZ_EZM_fnc_createCinematicCam;
+						[] spawn MAZ_EZM_fnc_enterCinematicCamera;
+
+						_camera camPreparePos _camSrc0;
 						_camera camPrepareTarget _camTarget;
-						_camera camSetFov 1;
 						_camera camCommitPrepared 0;
 
 						_camera camPreparePos _camSrc90;
@@ -9383,23 +9384,12 @@ MAZ_EZM_fnc_initFunction = {
 						cutRsc ["RscStatic", "PLAIN"];
 						sleep 0.4;
 
-						_camera cameraEffect ["terminate", "back"];
-						camDestroy _camera;
-
 						ppEffectDestroy HYPER_PP_CC_Cinematic;
 						
 						cutText ["", "BLACK IN", 2];
 						[1, 2, true, true] call BIS_fnc_cinemaBorder;
 
-						comment "Re-enable simulation on player vehicles";
-						if(player != vehicle player) then {
-							[vehicle player, true] remoteExec ["enableSimulationGlobal", 2];
-						};
-
-						if(_zeus) then {
-							sleep 0.2;
-							openCuratorInterface;
-						};
+						call MAZ_EZM_fnc_destroyCinematicCamera;
 					};
 					[[_target],HYPER_fnc_remoteCamera] remoteExec ["spawn", _allPlayers];
 				};

--- a/Enhanced_Zeus_Modules.sqf
+++ b/Enhanced_Zeus_Modules.sqf
@@ -9402,7 +9402,7 @@ MAZ_EZM_fnc_initFunction = {
 							playSoundUI ["a3\sounds_f\vehicles\air\heli_attack_01\heli_attack_01_ext_rotor.wss", 0.2];
 						};
 						[
-							parseText _briefingName,
+							parseText format ["<t size='2'>%1</t>",_briefingName],
 							parseText format["BREAKING NEWS - REPORTING LIVE FROM %1", worldName]
 						] spawn BIS_fnc_AAN;
 

--- a/Enhanced_Zeus_Modules.sqf
+++ b/Enhanced_Zeus_Modules.sqf
@@ -9386,16 +9386,16 @@ MAZ_EZM_fnc_initFunction = {
 						_camera cameraEffect ["terminate", "back"];
 						camDestroy _camera;
 
-						comment "Remove color correction right after cutscene is done so we don't have to remoteExec it";
 						ppEffectDestroy HYPER_PP_CC_Cinematic;
+						
+						cutText ["", "BLACK IN", 2];
+						[1, 2, true, true] call BIS_fnc_cinemaBorder;
 
 						comment "Re-enable simulation on player vehicles";
 						if(player != vehicle player) then {
 							[vehicle player, true] remoteExec ["enableSimulationGlobal", 2];
 						};
-						
-						cutText ["", "BLACK IN", 2];
-						[1, 2, true, true] call BIS_fnc_cinemaBorder;
+
 						if(_zeus) then {
 							sleep 0.2;
 							openCuratorInterface;
@@ -9406,7 +9406,7 @@ MAZ_EZM_fnc_initFunction = {
 				case "News": {
 					private _AANParams = [
 						parseText _briefingName,
-						parseText "BREAKING NEWS - LIVE"
+						parseText format["BREAKING NEWS - REPORTING LIVE FROM %1", worldName]
 					];
 					_AANParams remoteExec ["BIS_fnc_AAN", _allPlayers];
 					private _cam = call MAZ_EZM_fnc_createCinematicCam;
@@ -9423,9 +9423,14 @@ MAZ_EZM_fnc_initFunction = {
 					_cam setPosASL _posStart;
 
 					private _angle = 0;
+					private _zoom = 0.75;
 					while {_angle <= 180} do {
 						private _posMove = _pos getPos [200,_angle];
 						_posMove set [2,_height];
+
+						if (_angle > 45 && _angle < 135) then {
+							_cam camSetFov (_zoom - 0.01);
+						};
 
 						_cam camPreparePos (ASLtoAGL _posMove);
 						_cam camCommitPrepared 0.5;
@@ -9434,6 +9439,16 @@ MAZ_EZM_fnc_initFunction = {
 						_angle = _angle + 5;
 					};
 					call MAZ_EZM_fnc_destroyCinematicCamera;
+					[(uiNamespace getVariable "BIS_AAN"), 1] remoteExec ["closeDisplay", _allPlayers];
+					
+					HYPER_fnc_resetCutsceneUI = {
+						comment "Remove color correction right after cutscene is done so we don't have to remoteExec it";
+						ppEffectDestroy HYPER_PP_CC_Cinematic;
+						
+						cutText ["", "BLACK IN", 2];
+						[1, 2, true, true] call BIS_fnc_cinemaBorder;
+					};
+					[[], HYPER_fnc_resetCutsceneUI] remoteExec ["spawn", _allPlayers];
 				};
 			};
 		};

--- a/Enhanced_Zeus_Modules.sqf
+++ b/Enhanced_Zeus_Modules.sqf
@@ -9419,7 +9419,7 @@ MAZ_EZM_fnc_initFunction = {
 
 					private _pos = _target;
 					private _posASL = _pos;
-					private _height = 200;
+					private _height = (_posASL # 2) + 200;
 					_cam camPrepareTarget _pos;
 					_cam camCommitPrepared 0;
 

--- a/Enhanced_Zeus_Modules.sqf
+++ b/Enhanced_Zeus_Modules.sqf
@@ -9404,56 +9404,57 @@ MAZ_EZM_fnc_initFunction = {
 					[[_target],HYPER_fnc_remoteCamera] remoteExec ["spawn", _allPlayers];
 				};
 				case "News": {
-					[[],{
-						playSoundUI ["a3\sounds_f\vehicles\air\heli_attack_01\heli_attack_01_ext_rotor.wss", 0.2];
-						sleep 7.5;
-						playSoundUI ["a3\sounds_f\vehicles\air\heli_attack_01\heli_attack_01_ext_rotor.wss", 0.2];
-					}] remoteExec ["spawn", _allPlayers];
-					private _AANParams = [
-						parseText _briefingName,
-						parseText format["BREAKING NEWS - REPORTING LIVE FROM %1", worldName]
-					];
-					_AANParams remoteExec ["BIS_fnc_AAN", _allPlayers];
-					private _cam = call MAZ_EZM_fnc_createCinematicCam;
-					[] spawn MAZ_EZM_fnc_enterCinematicCamera;
-
-					private _pos = _target;
-					private _posASL = AGLToASL _pos;
-					private _height = (_posASL # 2) + 200;
-					_cam camPrepareTarget _pos;
-					_cam camCommitPrepared 0;
-
-					private _posStart = _pos getPos [200,0];
-					_posStart set [2,_height];
-					_cam setPosASL _posStart;
-
-					private _angle = 0;
-					private _zoom = 0.75;
-					while {_angle <= 155} do {
-						private _posMove = _pos getPos [200,_angle];
-						_posMove set [2,_height];
-
-						if (_angle > 45 && _angle < 135) then {
-							_cam camSetFov (_zoom - 0.01);
+					HYPER_fnc_remoteCamera = {
+						params ["_target", "_briefingName"];
+						[] spawn {
+							playSoundUI ["a3\sounds_f\vehicles\air\heli_attack_01\heli_attack_01_ext_rotor.wss", 0.2];
+							sleep 7.5;
+							playSoundUI ["a3\sounds_f\vehicles\air\heli_attack_01\heli_attack_01_ext_rotor.wss", 0.2];
 						};
+						[
+							parseText _briefingName,
+							parseText format["BREAKING NEWS - REPORTING LIVE FROM %1", worldName]
+						] spawn BIS_fnc_AAN;
 
-						_cam camPreparePos (ASLtoAGL _posMove);
-						_cam camCommitPrepared 0.5;
-						waitUntil { camCommitted _cam };
+						private _cam = call MAZ_EZM_fnc_createCinematicCam;
+						[] spawn MAZ_EZM_fnc_enterCinematicCamera;
 
-						_angle = _angle + 5;
-					};
-					call MAZ_EZM_fnc_destroyCinematicCamera;
-					[(uiNamespace getVariable "BIS_AAN"), 1] remoteExec ["closeDisplay", _allPlayers];
-					
-					HYPER_fnc_resetCutsceneUI = {
+						private _pos = _target;
+						private _posASL = AGLToASL _pos;
+						private _height = (_posASL # 2) + 200;
+						_cam camPrepareTarget _pos;
+						_cam camCommitPrepared 0;
+
+						private _posStart = _pos getPos [200,0];
+						_posStart set [2,_height];
+						_cam setPosASL _posStart;
+
+						private _angle = 0;
+						private _zoom = 0.75;
+						while {_angle <= 155} do {
+							private _posMove = _pos getPos [200,_angle];
+							_posMove set [2,_height];
+
+							if (_angle > 45 && _angle < 135) then {
+								_cam camSetFov (_zoom - 0.01);
+							};
+
+							_cam camPreparePos (ASLtoAGL _posMove);
+							_cam camCommitPrepared 0.5;
+							waitUntil { camCommitted _cam };
+
+							_angle = _angle + 5;
+						};
+						call MAZ_EZM_fnc_destroyCinematicCamera;
+						(uiNamespace getVariable "BIS_AAN") closeDisplay 1;
+						
 						comment "Remove color correction right after cutscene is done so we don't have to remoteExec it";
 						ppEffectDestroy HYPER_PP_CC_Cinematic;
 						
 						cutText ["", "BLACK IN", 2];
 						[1, 2, true, true] call BIS_fnc_cinemaBorder;
 					};
-					[[], HYPER_fnc_resetCutsceneUI] remoteExec ["spawn", _allPlayers];
+					[[_target, _briefingName],HYPER_fnc_remoteCamera] remoteExec ["spawn", _allPlayers];
 				};
 			};
 		};

--- a/Enhanced_Zeus_Modules.sqf
+++ b/Enhanced_Zeus_Modules.sqf
@@ -9204,14 +9204,6 @@ MAZ_EZM_fnc_initFunction = {
 
 	comment "Cinematics";
 
-		HYPER_EZM_fnc_showIntertitles = {
-			params ["_line1", "_line2"];
-			sleep 3;
-			_line1 spawn BIS_fnc_infoText;
-			sleep 5;
-			_line2 spawn BIS_fnc_infoText;
-		};
-
 		HYPER_EZM_fnc_splitMaxLine = {
 			params ["_inputString"];
 			private _maxLength = 22;
@@ -9335,8 +9327,6 @@ MAZ_EZM_fnc_initFunction = {
 			private _line1 = [_intertitles # 0] call HYPER_EZM_fnc_splitMaxLine;
 			private _line2 = [_intertitles # 1] call HYPER_EZM_fnc_splitMaxLine;
 			
-			[[_line1, _line2], HYPER_EZM_fnc_showIntertitles] remoteExec ["spawn", _allPlayers];
-
 			comment "Post processing";
 			switch (_postProcess) do {
 				case "none": {
@@ -9363,7 +9353,15 @@ MAZ_EZM_fnc_initFunction = {
 				case "Flyby": {
 					comment "in flyby mode, we select the module location as our target, and the camera paths are automatically designated at 0 and 90 degrees";
 					HYPER_fnc_remoteCamera = {
-						params ["_target"];
+						params ["_target", "_line1", "_line2"];
+						HYPER_EZM_fnc_showIntertitles = {
+							params ["_line1", "_line2"];
+							sleep 3;
+							_line1 spawn BIS_fnc_infoText;
+							sleep 5;
+							_line2 spawn BIS_fnc_infoText;
+						};
+						[_line1, _line2] spawn HYPER_EZM_fnc_showIntertitles;
 						private _zeus = !isNull (getAssignedCuratorLogic player);
 						private _camTarget = "Land_HelipadEmpty_F" createVehicleLocal _target;
 						private _circleRadius = 200;
@@ -9391,11 +9389,11 @@ MAZ_EZM_fnc_initFunction = {
 
 						call MAZ_EZM_fnc_destroyCinematicCamera;
 					};
-					[[_target],HYPER_fnc_remoteCamera] remoteExec ["spawn", _allPlayers];
+					[[_target, _line1, _line2],HYPER_fnc_remoteCamera] remoteExec ["spawn", _allPlayers];
 				};
 				case "News": {
 					HYPER_fnc_remoteCamera = {
-						params ["_target", "_briefingName"];
+						params ["_target", "_briefingName", "_line1", "_line2"];
 						[] spawn {
 							playSoundUI ["a3\sounds_f\vehicles\air\heli_attack_01\heli_attack_01_ext_rotor.wss", 0.2];
 							sleep 7.5;
@@ -9403,7 +9401,7 @@ MAZ_EZM_fnc_initFunction = {
 						};
 						[
 							parseText format ["<t size='2'>%1</t>",_briefingName],
-							parseText format["BREAKING NEWS - REPORTING LIVE FROM %1", worldName]
+							parseText format["// %1 - %2 // REPORTING LIVE FROM %3", _line1, _line2, worldName]
 						] spawn BIS_fnc_AAN;
 
 						private _cam = call MAZ_EZM_fnc_createCinematicCam;
@@ -9444,7 +9442,7 @@ MAZ_EZM_fnc_initFunction = {
 						cutText ["", "BLACK IN", 2];
 						[1, 2, true, true] call BIS_fnc_cinemaBorder;
 					};
-					[[_target, _briefingName],HYPER_fnc_remoteCamera] remoteExec ["spawn", _allPlayers];
+					[[_target, _briefingName, _intertitles # 0, _intertitles # 1],HYPER_fnc_remoteCamera] remoteExec ["spawn", _allPlayers];
 				};
 			};
 		};

--- a/Enhanced_Zeus_Modules.sqf
+++ b/Enhanced_Zeus_Modules.sqf
@@ -9286,13 +9286,6 @@ MAZ_EZM_fnc_initFunction = {
 			};
 			if (_author != "") then {_author = format [localize "STR_FORMAT_AUTHOR_SCRIPTED",_author];};
 
-			comment "Disable simulation on any vehicles to avoid crashing mid cutscene";
-			{
-				if (_x != vehicle _x) then {
-					[vehicle _x, false] remoteExec ["enableSimulationGlobal", 2];
-				};
-			} forEach allPlayers;
-
 			comment "Show intro titles";
 			private _track = switch (_backgroundSong) do {
 				case "epic": {"Music_Arrival"};

--- a/Enhanced_Zeus_Modules.sqf
+++ b/Enhanced_Zeus_Modules.sqf
@@ -9418,7 +9418,7 @@ MAZ_EZM_fnc_initFunction = {
 					[] spawn MAZ_EZM_fnc_enterCinematicCamera;
 
 					private _pos = _target;
-					private _posASL = _pos;
+					private _posASL = AGLToASL _pos;
 					private _height = (_posASL # 2) + 200;
 					_cam camPrepareTarget _pos;
 					_cam camCommitPrepared 0;

--- a/Enhanced_Zeus_Modules.sqf
+++ b/Enhanced_Zeus_Modules.sqf
@@ -10770,6 +10770,8 @@ MAZ_EZM_fnc_initFunction = {
 			_intelObj setPosATL _target;
 			_intelObj setObjectTextureGlobal [0, "a3\missions_f_orange\data\img\orange_compositions\c8\aan_co.paa"];
 
+			[_intelObj] call MAZ_EZM_fnc_ignoreWhenCleaning;
+
 			private _actionParams = [
 				_intelObj,
 				"<t color='#ff9b00'>View News Article</t>", 
@@ -10904,6 +10906,7 @@ MAZ_EZM_fnc_initFunction = {
 			private _intelObj = _intelObjModel createVehicle _target;
 			_intelObj setDamage 1;
 			_intelObj setPosATL _target;
+			[_intelObj] call MAZ_EZM_fnc_ignoreWhenCleaning;
 
 			private _actionParams = [
 				_intelObj,


### PR DESCRIPTION
This PR improves the intro cinematic engine by creating a new cinematic type called `News Helicopter`, which borrows the orbiting logic from the `Circle Cutscene` module, but includes a shorter radius rotation, AAN news overlays, a camera zoom effect, and helicopter sfx, while still supporting the interlude titles and audio options.

![image](https://github.com/user-attachments/assets/b5fb7ecc-b33c-4dbd-b039-b3ceebc04fa4)
![image](https://github.com/user-attachments/assets/2b98ac1e-95f6-43e3-9071-4f90a6c9fed3)
![image](https://github.com/user-attachments/assets/163e4201-869c-4283-81c4-df94fa09e3c7)

Tested on pub zeus server.